### PR TITLE
Plugin template- change `,` to `:`

### DIFF
--- a/NewRelic/config/plugin.template.json
+++ b/NewRelic/config/plugin.template.json
@@ -1,7 +1,7 @@
 {
   "agents": [
   	{
-      "seed_list" : ["host:port", "host,port"....],
+      "seed_list" : ["host:port", "host:port"....],
       "user" : "USERNAME",
       "password" : "PASSWORD",
       "clusterName" : "CLUSTER NAME"


### PR DESCRIPTION
Using a `:` to separate the host and port appears to be the only supported way to define the seed list. When using a `,` instead of a `:` the following error is given:
```
ERROR com.aerospike.newrelic.connector.AerospikeAgent - Error reading configuration parameters : java.lang.ArrayIndexOutOfBoundsException: 1
```